### PR TITLE
Fix lint errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ export default [
       ...react.configs['jsx-runtime'].rules,
       ...reactHooks.configs.recommended.rules,
       'react/jsx-no-target-blank': 'off',
+      'react/no-unknown-property': 'off',
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/src/pages/CarPhysics.jsx
+++ b/src/pages/CarPhysics.jsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
 import { Canvas, useFrame } from '@react-three/fiber'
 import { OrbitControls, SpotLight } from '@react-three/drei'
 import { Physics, RigidBody, CuboidCollider } from '@react-three/rapier'
@@ -55,6 +56,14 @@ function Car({ id, position, velocity, color, onRemoveCar }) {
       <CuboidCollider args={[1.5, 0.5, 1]} />
     </RigidBody>
   )
+}
+
+Car.propTypes = {
+  id: PropTypes.string.isRequired,
+  position: PropTypes.arrayOf(PropTypes.number).isRequired,
+  velocity: PropTypes.arrayOf(PropTypes.number).isRequired,
+  color: PropTypes.string.isRequired,
+  onRemoveCar: PropTypes.func.isRequired
 }
 
 function Ground() {
@@ -146,6 +155,10 @@ function Scene({ resetKey }) {
       <OrbitControls />
     </>
   )
+}
+
+Scene.propTypes = {
+  resetKey: PropTypes.number.isRequired
 }
 
 export default function CarPhysics() {

--- a/src/pages/ChromaticGate.jsx
+++ b/src/pages/ChromaticGate.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef } from 'react'
+import PropTypes from 'prop-types'
 import { Canvas, useFrame } from '@react-three/fiber'
 import { OrbitControls, Environment } from '@react-three/drei'
 import * as THREE from 'three'
@@ -155,6 +156,12 @@ function Gate() {
         />
       </mesh>
     )
+  }
+
+  Arch.propTypes = {
+    color: PropTypes.string.isRequired,
+    index: PropTypes.number.isRequired,
+    total: PropTypes.number.isRequired
   }
 
   return (

--- a/src/pages/Conveyor.jsx
+++ b/src/pages/Conveyor.jsx
@@ -1,6 +1,7 @@
 import { Canvas, useFrame } from '@react-three/fiber'
 import { OrbitControls, Html } from '@react-three/drei'
 import { useState, Suspense } from 'react'
+import PropTypes from 'prop-types'
 import { usePageTitle } from '../hooks/usePageTitle'
 
 function ScanLine({ dotted, running, sensorZ }) {
@@ -39,6 +40,12 @@ function ScanLine({ dotted, running, sensorZ }) {
   return <group>{segments}</group>
 }
 
+ScanLine.propTypes = {
+  dotted: PropTypes.bool.isRequired,
+  running: PropTypes.bool.isRequired,
+  sensorZ: PropTypes.number.isRequired
+}
+
 function Belt({ length = 20, width = 2 }) {
   return (
     <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
@@ -48,6 +55,11 @@ function Belt({ length = 20, width = 2 }) {
   )
 }
 
+Belt.propTypes = {
+  length: PropTypes.number,
+  width: PropTypes.number
+}
+
 function BoxItem({ position, color }) {
   return (
     <mesh position={position} castShadow>
@@ -55,6 +67,11 @@ function BoxItem({ position, color }) {
       <meshStandardMaterial color={color} />
     </mesh>
   )
+}
+
+BoxItem.propTypes = {
+  position: PropTypes.arrayOf(PropTypes.number).isRequired,
+  color: PropTypes.string.isRequired
 }
 
 function ConveyorScene() {

--- a/src/pages/Duck.jsx
+++ b/src/pages/Duck.jsx
@@ -1,4 +1,5 @@
 import { useRef, useMemo, useEffect } from 'react'
+import PropTypes from 'prop-types'
 import { Canvas, useFrame, extend } from '@react-three/fiber'
 import {
   OrbitControls,
@@ -28,6 +29,11 @@ function DuckPrimitive({ position, floatOffset }) {
   })
 
   return <primitive ref={group} object={clonedScene} position={position} />
+}
+
+DuckPrimitive.propTypes = {
+  position: PropTypes.arrayOf(PropTypes.number).isRequired,
+  floatOffset: PropTypes.number.isRequired
 }
 
 function Ocean() {

--- a/src/pages/Hoverboard.jsx
+++ b/src/pages/Hoverboard.jsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react'
+import PropTypes from 'prop-types'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { Physics, RigidBody, CuboidCollider } from '@react-three/rapier'
@@ -66,6 +67,11 @@ function InvisibleBoundary({ position, size }) {
       </mesh>
     </RigidBody>
   )
+}
+
+InvisibleBoundary.propTypes = {
+  position: PropTypes.arrayOf(PropTypes.number).isRequired,
+  size: PropTypes.arrayOf(PropTypes.number).isRequired
 }
 
 function Boundaries() {


### PR DESCRIPTION
## Summary
- silence `react/no-unknown-property` as we use React Three Fiber
- add PropTypes to satisfy `react/prop-types` rule across pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683e3bbb81e8832a85c80badcf5927d2