### PR TITLE
Add Prettier formatter and docs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "trailingComma": "es5"
+}

--- a/FORMATTING_AND_LINTING.md
+++ b/FORMATTING_AND_LINTING.md
@@ -1,0 +1,19 @@
+# Formatting and Linting
+
+This project uses **Prettier** for code formatting and **ESLint** for linting.
+
+## Running the formatter
+
+```bash
+npm run format
+```
+
+This command runs Prettier on the entire project, rewriting files in place.
+
+## Running the linter
+
+```bash
+npm run lint
+```
+
+This command checks the codebase using ESLint and reports any issues.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
+        "prettier": "^3.5.3",
         "vite": "^6.0.5"
       }
     },
@@ -4692,6 +4693,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/promise-worker-transferable": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "format": "prettier --write .",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
+    "prettier": "^3.5.3",
     "vite": "^6.0.5"
   }
 }


### PR DESCRIPTION
## Summary
- add Prettier config and ignore files
- install Prettier and add a `format` npm script
- document how to run lint and format commands

## Testing
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_683e52ab5a80832abed49b191fa4a376