### PR TITLE
Remove orbit helper text

### DIFF
--- a/src/pages/Conveyor.jsx
+++ b/src/pages/Conveyor.jsx
@@ -176,9 +176,6 @@ export default function Conveyor() {
         </Suspense>
         <OrbitControls makeDefault />
       </Canvas>
-      <div className='absolute bottom-4 right-4 text-white/70 text-xs pointer-events-none'>
-        Click & drag to orbit
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- delete the "Click & drag to orbit" overlay from the conveyor page
- revert README since we didn't need a blurb about it

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683e81be604c832a9c14025e5180b40f