### PR TITLE
Add 3D index carousel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,4 @@
 - If you edit any file under `src/pages` or `README.md`, you **must** also update `README.md` with a brief, funny, sarcastic blurb about the change.
 - Always run `npm run format` and `npm run lint` before committing.
 - Keep humor and sarcasm consistent with the existing README style.
+- When adding or removing a demo page under `src/pages`, make sure `src/pages/Index.jsx` reflects the change so the gallery stays in sync.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 ## 🎪 Welcome to the Circus
 
+### 🗂️ The Not-So-Grand Gallery [@third-time-charm/](https://davidyen1124.github.io/third-time-charm/)
+
+For those who want a guided tour of my questionable Three.js experiments, the gallery now whirls them around you in a flashy carousel. Because a plain grid was apparently too pedestrian.
+
 ### 🔒 The Pink Prisoner [@third-time-charm/lockedin](https://davidyen1124.github.io/third-time-charm/lockedin)
 
 Behold, a 3D masterpiece where a pink humanoid is forever trapped in a cylindrical cage! Built with Three.js because apparently, 2D wasn't complicated enough. Watch in amazement as our blocky friend eternally rotates like a sad display item at a department store. Features include: anatomically questionable proportions, a hairstyle that defies gravity, and enough geometry to make Euclid proud.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import Index from './pages/Index'
 import LockedIn from './pages/LockedIn'
 import Hoverboard from './pages/Hoverboard'
 import ChromaticGate from './pages/ChromaticGate'
@@ -13,6 +14,7 @@ function App() {
       <div className="flex flex-col min-h-screen">
         <main className="flex-grow">
           <Routes>
+            <Route path="/" element={<Index />} />
             <Route path="/lockedin" element={<LockedIn />} />
             <Route path="/hoverboard" element={<Hoverboard />} />
             <Route path="/chromatic-gate" element={<ChromaticGate />} />

--- a/src/pages/Index.jsx
+++ b/src/pages/Index.jsx
@@ -1,0 +1,91 @@
+import { Canvas, useFrame } from '@react-three/fiber'
+import { Image, OrbitControls } from '@react-three/drei'
+import { usePageTitle } from '../hooks/usePageTitle'
+import { useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import PropTypes from 'prop-types'
+
+const demos = [
+  {
+    path: '/lockedin',
+    name: 'The Pink Prisoner',
+    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/locked-in.png',
+  },
+  {
+    path: '/hoverboard',
+    name: 'The Physics-Defying Dude',
+    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/hoverboard.png',
+  },
+  {
+    path: '/chromatic-gate',
+    name: 'The Chromatic Gate',
+    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/chromatic-gate.png',
+  },
+  {
+    path: '/car-physics',
+    name: 'The Physics-Challenged Cars',
+    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/car-physics.png',
+  },
+  {
+    path: '/duck',
+    name: 'The Rubber Duck Flotilla',
+    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/duck.png',
+  },
+  {
+    path: '/polaroid',
+    name: 'The Spotlight Polaroids',
+    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/polaroid.png',
+  },
+  {
+    path: '/conveyor',
+    name: 'The Grocery Lane Conveyor',
+    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/conveyor.png',
+  },
+]
+
+function Carousel({ items }) {
+  const group = useRef()
+  const navigate = useNavigate()
+  useFrame((_, delta) => {
+    if (group.current) group.current.rotation.y += delta * 0.5
+  })
+
+  const radius = 4
+  return (
+    <group ref={group}>
+      {items.map((demo, i) => {
+        const angle = (i / items.length) * Math.PI * 2
+        return (
+          <Image
+            key={demo.path}
+            url={demo.img}
+            position={[Math.sin(angle) * radius, 0, Math.cos(angle) * radius]}
+            scale={[2.4, 1.6, 1]}
+            rotation={[0, angle + Math.PI, 0]}
+            onClick={() => navigate(demo.path)}
+          />
+        )
+      })}
+    </group>
+  )
+}
+
+Carousel.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+}
+
+export default function Index() {
+  usePageTitle('The Not-So-Grand Gallery')
+  return (
+    <div className="relative h-screen bg-gray-900">
+      <Canvas className="absolute inset-0">
+        <ambientLight intensity={0.5} />
+        <Carousel items={demos} />
+        <OrbitControls enableZoom={false} />
+      </Canvas>
+      <h1 className="absolute top-4 left-1/2 -translate-x-1/2 text-3xl font-bold text-white">
+        Third Time Charm Gallery
+      </h1>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- showcase demos in a Three.js carousel on the index page
- document the new gallery behavior in AGENTS.md
- update README with a sarcastic blurb about the spinning gallery

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683e81e11928832a9cf6fe8e36a5a6ce