### PR TITLE
Use local screenshots for gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 For those who want a guided tour of my questionable Three.js experiments, the gallery now whirls them around you in a flashy carousel. Because a plain grid was apparently too pedestrian.
 
+By the way, the thumbnails now come from local files, because waiting on GitHub to deliver them felt slower than my Monday brain.
+Now they're stashed in `.github/assets` because even images need their own secret clubhouse.
+The conveyor screenshot is on an extended coffee break, so the carousel is short one picture for now.
+
 ### 🔒 The Pink Prisoner [@third-time-charm/lockedin](https://davidyen1124.github.io/third-time-charm/lockedin)
 
 Behold, a 3D masterpiece where a pink humanoid is forever trapped in a cylindrical cage! Built with Three.js because apparently, 2D wasn't complicated enough. Watch in amazement as our blocky friend eternally rotates like a sad display item at a department store. Features include: anatomically questionable proportions, a hairstyle that defies gravity, and enough geometry to make Euclid proud.

--- a/src/pages/Index.jsx
+++ b/src/pages/Index.jsx
@@ -5,41 +5,44 @@ import { useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
+// 👇 local copies of the screenshots
+import lockedIn from '../../.github/assets/screenshots/locked-in.png'
+import hoverboard from '../../.github/assets/screenshots/hoverboard.png'
+import chromaticGate from '../../.github/assets/screenshots/chromatic-gate.png'
+import carPhysics from '../../.github/assets/screenshots/car-physics.png'
+import duck from '../../.github/assets/screenshots/duck.png'
+import polaroid from '../../.github/assets/screenshots/polaroid.png'
+
 const demos = [
   {
     path: '/lockedin',
     name: 'The Pink Prisoner',
-    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/locked-in.png',
+    img: lockedIn,
   },
   {
     path: '/hoverboard',
     name: 'The Physics-Defying Dude',
-    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/hoverboard.png',
+    img: hoverboard,
   },
   {
     path: '/chromatic-gate',
     name: 'The Chromatic Gate',
-    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/chromatic-gate.png',
+    img: chromaticGate,
   },
   {
     path: '/car-physics',
     name: 'The Physics-Challenged Cars',
-    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/car-physics.png',
+    img: carPhysics,
   },
   {
     path: '/duck',
     name: 'The Rubber Duck Flotilla',
-    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/duck.png',
+    img: duck,
   },
   {
     path: '/polaroid',
     name: 'The Spotlight Polaroids',
-    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/polaroid.png',
-  },
-  {
-    path: '/conveyor',
-    name: 'The Grocery Lane Conveyor',
-    img: 'https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/conveyor.png',
+    img: polaroid,
   },
 ]
 


### PR DESCRIPTION
## Summary
- move gallery thumbnails to local repo and import them
- mention local thumbnail change in README
- drop missing conveyor thumbnail from carousel

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683e89a07d9c832aa46255375c675208