### PR TITLE
Fix build errors with three updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Step right up to The Chromatic Gate, where gravity and reason have taken a coffe
 
 <img src="https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/chromatic-gate.png" width="600" alt="Chromatic Gate Preview" />
 
+Now powered by `SRGBColorSpace` because `sRGBEncoding` finally retired. Progress?
+
 ### 🚗 The Physics-Challenged Cars [@third-time-charm/car-physics](https://davidyen1124.github.io/third-time-charm/car-physics)
 
 Welcome to our very own demolition derby, where four colorful cars have decided that Newton's laws are more like "suggestions." Watch as these rainbow-hued boxes of chaos launch themselves from the corners of our green stage, determined to recreate a particle collision experiment that would make CERN scientists scratch their heads. Each reset brings a fresh palette of colors because if you're going to break the laws of physics, you might as well do it in style. Click anywhere to restart the mayhem when the cars inevitably yeet themselves into the void. Warning: No actual cars were harmed in the making of this demo, but several physics textbooks filed formal complaints.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2",
         "tailwindcss": "^4.1.8",
-        "three": "^0.177.0"
+        "three": "^0.177.0",
+        "three-stdlib": "^2.36.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.28.0",
@@ -5468,9 +5469,9 @@
       }
     },
     "node_modules/three-stdlib": {
-      "version": "2.35.13",
-      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.35.13.tgz",
-      "integrity": "sha512-AbXVObkM0OFCKX0r4VmHguGTdebiUQA+Yl+4VNta1wC158gwY86tCkjp2LFfmABtjYJhdK6aP13wlLtxZyLMAA==",
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.0.tgz",
+      "integrity": "sha512-kv0Byb++AXztEGsULgMAs8U2jgUdz6HPpAB/wDJnLiLlaWQX2APHhiTJIN7rqW+Of0eRgcp7jn05U1BsCP3xBA==",
       "license": "MIT",
       "dependencies": {
         "@types/draco3d": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",
     "tailwindcss": "^4.1.8",
-    "three": "^0.177.0"
+    "three": "^0.177.0",
+    "three-stdlib": "^2.36.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",

--- a/src/pages/ChromaticGate.jsx
+++ b/src/pages/ChromaticGate.jsx
@@ -191,7 +191,7 @@ export default function ChromaticGate() {
         gl={{
           physicallyCorrectLights: true,
           toneMapping: THREE.ACESFilmicToneMapping,
-          outputEncoding: THREE.sRGBEncoding,
+          outputColorSpace: THREE.SRGBColorSpace,
         }}
       >
         <color attach="background" args={['#87CEEB']} />


### PR DESCRIPTION
## Summary
- update three-stdlib to v2.36.0
- adapt Chromatic Gate page to use `SRGBColorSpace`
- add README note about the color space change

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842a04414f8832aa2226b38e2ab0e70