### PR TITLE
Add aircraft marshaller demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Turns out length belongs on Z, so the cubes can strut forward like runway models
 
 <img src="https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/conveyor.png" width="600" alt="Conveyor Preview" />
 
+### ✈️ The Runway Maestro [@third-time-charm/marshaller](https://davidyen1124.github.io/third-time-charm/marshaller)
+
+Because nothing says "professional" like a pixelated dude enthusiastically waving glow sticks at invisible airplanes. He keeps signaling, even though no planes ever listen. Safety regulations probably weren't consulted. The screenshot union refused to work overtime, so you'll just have to imagine the dazzling moves.
+
 ## 🙌 Special Thanks To
 
 - My therapist - For helping me cope with React's lifecycle methods

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import CarPhysics from './pages/CarPhysics'
 import Duck from './pages/Duck'
 import Polaroid from './pages/Polaroid'
 import Conveyor from './pages/Conveyor'
+import Marshaller from './pages/Marshaller'
 
 function App() {
   return (
@@ -22,6 +23,7 @@ function App() {
             <Route path="/duck" element={<Duck />} />
             <Route path="/polaroid" element={<Polaroid />} />
             <Route path="/conveyor" element={<Conveyor />} />
+            <Route path="/marshaller" element={<Marshaller />} />
           </Routes>
         </main>
       </div>

--- a/src/pages/Index.jsx
+++ b/src/pages/Index.jsx
@@ -1,5 +1,5 @@
 import { Canvas, useFrame } from '@react-three/fiber'
-import { Image, OrbitControls } from '@react-three/drei'
+import { Image, OrbitControls, Html } from '@react-three/drei'
 import { usePageTitle } from '../hooks/usePageTitle'
 import { useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -50,6 +50,10 @@ const demos = [
     name: 'The Grocery Lane Conveyor',
     img: conveyor,
   },
+  {
+    path: '/marshaller',
+    name: 'The Runway Maestro',
+  },
 ]
 
 function Carousel({ items }) {
@@ -64,15 +68,34 @@ function Carousel({ items }) {
     <group ref={group}>
       {items.map((demo, i) => {
         const angle = (i / items.length) * Math.PI * 2
+        const pos = [Math.sin(angle) * radius, 0, Math.cos(angle) * radius]
+        const rot = [0, angle + Math.PI, 0]
+        if (demo.img) {
+          return (
+            <Image
+              key={demo.path}
+              url={demo.img}
+              position={pos}
+              scale={[2.4, 1.6, 1]}
+              rotation={rot}
+              onClick={() => navigate(demo.path)}
+            />
+          )
+        }
         return (
-          <Image
+          <mesh
             key={demo.path}
-            url={demo.img}
-            position={[Math.sin(angle) * radius, 0, Math.cos(angle) * radius]}
+            position={pos}
+            rotation={rot}
             scale={[2.4, 1.6, 1]}
-            rotation={[0, angle + Math.PI, 0]}
             onClick={() => navigate(demo.path)}
-          />
+          >
+            <planeGeometry args={[1, 1]} />
+            <meshStandardMaterial color="gray" />
+            <Html center>
+              <div className="text-white text-xs">{demo.name}</div>
+            </Html>
+          </mesh>
         )
       })}
     </group>

--- a/src/pages/Marshaller.jsx
+++ b/src/pages/Marshaller.jsx
@@ -1,0 +1,58 @@
+import { Canvas, useFrame } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
+import { useRef } from 'react'
+import { usePageTitle } from '../hooks/usePageTitle'
+import Man from '../components/man'
+
+function ManWithWands() {
+  const leftWand = useRef()
+  const rightWand = useRef()
+  useFrame((state) => {
+    const t = state.clock.getElapsedTime()
+    if (leftWand.current) leftWand.current.rotation.z = Math.sin(t) * 0.5
+    if (rightWand.current) rightWand.current.rotation.z = -Math.sin(t) * 0.5
+  })
+  return (
+    <group>
+      <Man />
+      <mesh
+        ref={leftWand}
+        position={[-0.45, 1, 0]}
+        rotation={[0, 0, Math.PI / 2]}
+      >
+        <cylinderGeometry args={[0.05, 0.05, 1, 16]} />
+        <meshStandardMaterial
+          color="orange"
+          emissive="red"
+          emissiveIntensity={2}
+        />
+      </mesh>
+      <mesh
+        ref={rightWand}
+        position={[0.45, 1, 0]}
+        rotation={[0, 0, -Math.PI / 2]}
+      >
+        <cylinderGeometry args={[0.05, 0.05, 1, 16]} />
+        <meshStandardMaterial
+          color="orange"
+          emissive="red"
+          emissiveIntensity={2}
+        />
+      </mesh>
+    </group>
+  )
+}
+
+export default function Marshaller() {
+  usePageTitle('The Runway Maestro')
+  return (
+    <div className="w-full h-screen flex items-center justify-center bg-gray-900">
+      <Canvas camera={{ position: [0, 2, 5], fov: 50 }}>
+        <ambientLight intensity={0.4} />
+        <directionalLight position={[5, 5, 5]} intensity={0.8} />
+        <ManWithWands />
+        <OrbitControls enablePan={false} enableZoom={false} />
+      </Canvas>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- showcase an overly enthusiastic runway marshaller waving wands (no screenshot)
- wire up new page in router and gallery
- tweak gallery to show a placeholder panel when an image is missing
- update README with a snarky note about the missing screenshot

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843c3fedfb4832ab98c0aff00d78037