### PR TITLE
Remove screenshot from flight simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Turns out length belongs on Z, so the cubes can strut forward like runway models
 
 <img src="https://github.com/davidyen1124/third-time-charm/raw/main/.github/assets/screenshots/conveyor.png" width="600" alt="Conveyor Preview" />
 
+### ✈️ The Realistic Flight Simulator [@third-time-charm/flight-simulator](https://davidyen1124.github.io/third-time-charm/flight-simulator)
+
+Because nothing screams "realism" like a plane constructed from three boxes and a dream. Watch it circle endlessly, ignoring all known aerodynamics, while you contemplate your life choices.
+
 ## 🙌 Special Thanks To
 
 - My therapist - For helping me cope with React's lifecycle methods
@@ -69,3 +73,4 @@ Turns out length belongs on Z, so the cubes can strut forward like runway models
 - My coffee machine - The real senior developer on this project
 - Prettier went on a formatting spree across the demo pages, so now everything is perfectly aligned and mildly smug about it.
 - The conveyor screenshot finally rolled onto the homepage, so the carousel doesn't look like it's missing a tooth anymore.
+- The flight simulator is buzzing around without a screenshot, proving anything can fly with enough JavaScript and imagination.

--- a/src/pages/FlightSimulator.jsx
+++ b/src/pages/FlightSimulator.jsx
@@ -1,0 +1,65 @@
+import { Canvas, useFrame } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
+import { useRef } from 'react'
+import { usePageTitle } from '../hooks/usePageTitle'
+
+function Plane() {
+  const ref = useRef()
+  const angle = useRef(0)
+  useFrame((_, delta) => {
+    angle.current += delta * 0.3
+    const a = angle.current
+    const radius = 10
+    ref.current.position.set(
+      Math.sin(a) * radius,
+      5 + Math.sin(a * 2),
+      Math.cos(a) * radius
+    )
+    ref.current.rotation.y = a + Math.PI / 2
+    ref.current.rotation.z = Math.sin(a * 2) * 0.1
+  })
+  return (
+    <group ref={ref}>
+      <mesh>
+        <boxGeometry args={[1.5, 0.3, 4]} />
+        <meshStandardMaterial color="white" />
+      </mesh>
+      {/* wings */}
+      <mesh position={[0, 0, 0]}>
+        <boxGeometry args={[6, 0.1, 1]} />
+        <meshStandardMaterial color="red" />
+      </mesh>
+      <mesh position={[0, -0.2, -1.5]}>
+        <boxGeometry args={[1, 0.1, 1]} />
+        <meshStandardMaterial color="blue" />
+      </mesh>
+    </group>
+  )
+}
+
+function Scene() {
+  return (
+    <>
+      <color attach="background" args={[0x87ceeb]} />
+      <ambientLight intensity={0.5} />
+      <directionalLight position={[10, 20, 10]} intensity={1} />
+      <Plane />
+      <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
+        <planeGeometry args={[200, 200]} />
+        <meshStandardMaterial color="green" />
+      </mesh>
+      <OrbitControls />
+    </>
+  )
+}
+
+export default function FlightSimulator() {
+  usePageTitle('The Realistic Flight Simulator')
+  return (
+    <div className="w-full h-screen">
+      <Canvas camera={{ position: [20, 10, 20], fov: 60 }}>
+        <Scene />
+      </Canvas>
+    </div>
+  )
+}

--- a/src/pages/Index.jsx
+++ b/src/pages/Index.jsx
@@ -50,6 +50,10 @@ const demos = [
     name: 'The Grocery Lane Conveyor',
     img: conveyor,
   },
+  {
+    path: '/flight-simulator',
+    name: 'The Realistic Flight Simulator',
+  },
 ]
 
 function Carousel({ items }) {


### PR DESCRIPTION
## Summary
- remove the flight simulator screenshot asset
- drop screenshot references from README and gallery entry
- add a snarky note about screenshotlessness

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843c334a6e8832aa4ab75f4cbc3ca86