### PR TITLE
Add Realistic Flight Simulator page

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Turns out length belongs on Z, so the cubes can strut forward like runway models
 
 Because nothing says "professional" like a pixelated dude enthusiastically waving glow sticks at invisible airplanes. He keeps signaling, even though no planes ever listen. Safety regulations probably weren't consulted. The screenshot union refused to work overtime, so you'll just have to imagine the dazzling moves.
 
+### 🛫 The Realistic Flight Simulator [@third-time-charm/flight-simulator](https://davidyen1124.github.io/third-time-charm/flight-simulator)
+
+Introducing the world's finest paper airplane technology. Marvel as a blocky cone soars through the digital skies with all the grace of a toddler's arts-and-crafts project. If this is realism, birds everywhere are offended.
+
 ## 🙌 Special Thanks To
 
 - My therapist - For helping me cope with React's lifecycle methods

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Duck from './pages/Duck'
 import Polaroid from './pages/Polaroid'
 import Conveyor from './pages/Conveyor'
 import Marshaller from './pages/Marshaller'
+import RealisticFlightSimulator from './pages/RealisticFlightSimulator'
 
 function App() {
   return (
@@ -24,6 +25,10 @@ function App() {
             <Route path="/polaroid" element={<Polaroid />} />
             <Route path="/conveyor" element={<Conveyor />} />
             <Route path="/marshaller" element={<Marshaller />} />
+            <Route
+              path="/flight-simulator"
+              element={<RealisticFlightSimulator />}
+            />
           </Routes>
         </main>
       </div>

--- a/src/pages/Index.jsx
+++ b/src/pages/Index.jsx
@@ -13,6 +13,7 @@ import carPhysics from '../../.github/assets/screenshots/car-physics.png'
 import duck from '../../.github/assets/screenshots/duck.png'
 import polaroid from '../../.github/assets/screenshots/polaroid.png'
 import conveyor from '../../.github/assets/screenshots/conveyor.png'
+// no screenshot yet for the flight simulator, imagination required
 
 const demos = [
   {
@@ -53,6 +54,10 @@ const demos = [
   {
     path: '/marshaller',
     name: 'The Runway Maestro',
+  },
+  {
+    path: '/flight-simulator',
+    name: 'The Realistic Flight Simulator',
   },
 ]
 

--- a/src/pages/RealisticFlightSimulator.jsx
+++ b/src/pages/RealisticFlightSimulator.jsx
@@ -1,0 +1,43 @@
+import { Canvas, useFrame } from '@react-three/fiber'
+import { OrbitControls } from '@react-three/drei'
+import { useRef } from 'react'
+import { usePageTitle } from '../hooks/usePageTitle'
+
+function PaperPlane() {
+  const ref = useRef()
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime()
+    if (ref.current) {
+      ref.current.position.z = (-t * 2) % 50
+      ref.current.position.y = Math.sin(t) * 2
+      ref.current.rotation.y = Math.sin(t * 0.5) * 0.5
+    }
+  })
+
+  return (
+    <group ref={ref} position={[0, 0, 0]}>
+      <mesh rotation={[Math.PI / 2, 0, 0]}>
+        <coneGeometry args={[0.5, 2, 8]} />
+        <meshStandardMaterial color="white" />
+      </mesh>
+      <mesh position={[0, 0, -1]} rotation={[0, 0, 0]}>
+        <boxGeometry args={[2, 0.1, 1]} />
+        <meshStandardMaterial color="lightgray" />
+      </mesh>
+    </group>
+  )
+}
+
+export default function RealisticFlightSimulator() {
+  usePageTitle('The Realistic Flight Simulator')
+  return (
+    <div className="w-full h-screen bg-sky-400">
+      <Canvas camera={{ position: [10, 5, 10] }}>
+        <ambientLight intensity={0.6} />
+        <directionalLight position={[5, 10, 5]} intensity={0.8} />
+        <PaperPlane />
+        <OrbitControls />
+      </Canvas>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add new Realistic Flight Simulator page with paper plane animation
- route the new page in `App.jsx`
- list the demo in the gallery index
- document the feature with a sarcastic blurb in `README`

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684cdd0d2cc0832abebe0c4669c0099f